### PR TITLE
Add markdown processing for method, property, event details

### DIFF
--- a/lib/markup.js
+++ b/lib/markup.js
@@ -23,9 +23,25 @@ module.exports = (doc) => {
     if (description) {
       document.attributes.description = highlight(description)
     }
+
+    replaceDescriptionFor(document.attributes.methods)
+    replaceDescriptionFor(document.attributes.properties)
+    replaceDescriptionFor(document.attributes.events)
+
   })
 
   return doc
+}
+
+function replaceDescriptionFor(items) {
+  if (items) {
+    items.forEach(item => {
+      let itemDescription = item.description
+      if (itemDescription) {
+        item.description = highlight(itemDescription)
+      }
+    })
+  }
 }
 
 function highlight (description) {


### PR DESCRIPTION
Fixes https://github.com/ember-learn/ember-api-docs/issues/82

This is pretty process intensive, and we will need to up node's heap size a bit for this.  the theory is we take the hit for rendering the markdown once at build time, instead of in each individual client.  (eco-friendly ;-)

Run `node --max_old_space_size=8192 index.js` to avoid running out of memory.