### PR TITLE
fix mixed logical operators to make standardjs happy

### DIFF
--- a/lib/modules-transform.js
+++ b/lib/modules-transform.js
@@ -8,9 +8,9 @@ function addSubModulesParentAttribute (moduleObj) {
 }
 
 function filterStaticAndDerived (classes, className) {
-  let included = (classes.hasOwnProperty(className) &&
+  let included = ((classes.hasOwnProperty(className) &&
                   !classes[className].hasOwnProperty('static') &&
-                  classes[className].hasOwnProperty('file') ||
+                  classes[className].hasOwnProperty('file')) ||
                   !classes.hasOwnProperty(className))
   return included
 }


### PR DESCRIPTION
Address CI test failure introduced at https://github.com/ember-learn/ember-jsonapi-docs/pull/42 Unblocks CI for https://github.com/ember-learn/ember-jsonapi-docs/pull/44

StandardJS does not allow mixed && and || without parens. Please check my logic:

```
false && true  || true      // returns true
false && (true || true)     // returns false
```

So I wrapped the && operators in parens:
```
let included = ((classes.hasOwnProperty(className) &&
                  !classes[className].hasOwnProperty('static') &&
                  classes[className].hasOwnProperty('file')) ||
                  !classes.hasOwnProperty(className))
```

[MDN reference](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Logical_Operators)