### PR TITLE
create tmp and s3docs dirs if not there

### DIFF
--- a/generate-local.sh
+++ b/generate-local.sh
@@ -9,6 +9,8 @@ if [ "$COMMAND" == 'yui' ]
         echo "🚚 💨  Copying docs output to ember-jsonapi-docs for version $1... 🚚 💨 "
         rm -rf ../ember-jsonapi-docs/tmp/s3-docs/v$VERSION
         rm -rf ../ember-jsonapi-docs/tmp/json-docs/$PROJECT/$VERSION
+        mkdir ../ember-jsonapi-docs/tmp
+        mkdir ../ember-jsonapi-docs/tmp/s3-docs
         mkdir ../ember-jsonapi-docs/tmp/s3-docs/v$VERSION
         cp -fv docs/data.json ../ember-jsonapi-docs/tmp/s3-docs/v$VERSION/ember-docs.json
 fi


### PR DESCRIPTION
on first install, the generate script fails because the `tmp` and `tmp/s3docs` directories don't yet exist.