### PR TITLE
Cross-platform script. Linux & macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@ Setting `export SKIP_S3_SYNC=yes` will stop the generator from syncing s3 conten
 
 ## Generating API Documentation and Testing API Docs Locally
 
-1. Clone the following 3 repositories into a single parent directory
+1. Clone the following 3 repositories into a single parent directory. Install dependencies for each app as described in their respective `README` files.
    - [ember.js](https://github.com/emberjs/ember.js)
    - [ember-jsonapi-docs](https://github.com/ember-learn/ember-jsonapi-docs)
    - [ember-api-docs](https://github.com/ember-learn/ember-api-docs)
-2. Set up the project according to the instructions above in `Running the app`.
-3. From the `ember-jsonapi-docs` directory, run `./generate-local.sh yui ember 2.16.0`. This command runs the Ember documentation build, generates jsonapi output, and copies it to the `ember-api-docs` directory.
-4. Run the API app with the newly generated local data by running `API_HOST=http://localhost:4200 ember s` in the `ember-api-docs` directory.
+1. Set up the project according to the instructions above in `Running the app`.
+1. From the `ember-jsonapi-docs` directory, run `./generate-local.sh yui ember 2.18.0`. This command runs the Ember documentation build, generates jsonapi output, and copies it to the `ember-api-docs` directory.
+   - _If you encounter an error like `ember-2.18.0 has already been indexed in json-docs`, then use a new unique version number like `2.18.1`, or whatever is appropriate._ 
+1. Run the API app with the newly generated local data by running `API_HOST=http://localhost:4200 ember s` in the `ember-api-docs` directory.
+

--- a/generate-local.sh
+++ b/generate-local.sh
@@ -1,31 +1,36 @@
+#!/usr/bin/env bash
+
 PROJECT=${2:-ember}
 VERSION=${3:-2.16.0}
 COMMAND=${1:-json}
+
 if [ "$COMMAND" == 'yui' ]
-    then
-        cd ../ember.js
-        echo "🏃 💨  Running ember docs build 🏃 💨"
-        npm run docs
-        echo "🚚 💨  Copying docs output to ember-jsonapi-docs for version $1... 🚚 💨 "
-        rm -rf ../ember-jsonapi-docs/tmp/s3-docs/v$VERSION
-        rm -rf ../ember-jsonapi-docs/tmp/json-docs/$PROJECT/$VERSION
-        mkdir ../ember-jsonapi-docs/tmp
-        mkdir ../ember-jsonapi-docs/tmp/s3-docs
-        mkdir ../ember-jsonapi-docs/tmp/s3-docs/v$VERSION
-        cp -fv docs/data.json ../ember-jsonapi-docs/tmp/s3-docs/v$VERSION/ember-docs.json
+then
+    cd ../ember.js
+    echo "🏃 💨  Running ember docs build 🏃 💨"
+    npm run docs
+    echo "🚚 💨  Copying docs output to ember-jsonapi-docs for version $1... 🚚 💨 "
+    rm -rf ../ember-jsonapi-docs/tmp/s3-docs/v$VERSION
+    rm -rf ../ember-jsonapi-docs/tmp/json-docs/$PROJECT/$VERSION
+    mkdir -p ../ember-jsonapi-docs/tmp
+    mkdir -p ../ember-jsonapi-docs/tmp/s3-docs
+    mkdir -p ../ember-jsonapi-docs/tmp/s3-docs/v$VERSION
+    cp -fv docs/data.json ../ember-jsonapi-docs/tmp/s3-docs/v$VERSION/ember-docs.json
 fi
+
 cd ../ember-jsonapi-docs
 echo "🏃 💨  Running ember-jsonapi-docs for version $VERSION 🏃 💨 "
 yarn start -- --project $PROJECT --version $VERSION
 echo "🚚 💨  Copying rev-index json file to ember-api-docs app... 🚚 💨 "
 rm -f ../ember-api-docs/public/rev-index/$PROJECT-$VERSION.json
-mkdir ../ember-api-docs/public/rev-index
+mkdir -p ../ember-api-docs/public/rev-index
 cp -v tmp/rev-index/$PROJECT.json ../ember-api-docs/public/rev-index/
 cp -fv tmp/rev-index/$PROJECT-$VERSION.json ../ember-api-docs/public/rev-index/
 echo "🚚 💨  Copying json-docs structure to ember-api-docs app... 🚚 💨 "
 rm -rf ../ember-api-docs/public/json-docs/$PROJECT/$VERSION
-mkdir ../ember-api-docs/public/json-docs/
-mkdir ../ember-api-docs/public/json-docs/$PROJECT
-mkdir ../ember-api-docs/public/json-docs/$PROJECT/$VERSION
-cp -rf tmp/json-docs/$PROJECT/$VERSION/ ../ember-api-docs/public/json-docs/$PROJECT/$VERSION/
+mkdir -p ../ember-api-docs/public/json-docs/
+mkdir -p ../ember-api-docs/public/json-docs/$PROJECT
+mkdir -p ../ember-api-docs/public/json-docs/$PROJECT/$VERSION
+cp -rf tmp/json-docs/$PROJECT/$VERSION/* ../ember-api-docs/public/json-docs/$PROJECT/$VERSION/
 echo "🎉🎉🎉 DONE 🎉🎉🎉"
+


### PR DESCRIPTION
Update `generate-local.sh` to work on both macOS and Linux. It seems `cp -r` behaves differently on Linux and macOS (verified on Arch and Ubuntu).

When running `generate-locale.sh` it ends up calling something along the lines of `cp -rv ../src/2.18.1/ ../dst/2.18.1/` and creates `../dst/2.18.1/2.18.1` in `ember-api-docs` on Linux. 

That behavior seems weird to me, and does not exist on Darwin/macOS. Seems to only happen with GNU `cp`.

```
# Bad behavior on Linux
$ rm -rf /tmp/{a,b}; mkdir -p /tmp/{a,b}/1; touch /tmp/a/1/test.txt; cp -rv /tmp/a/1/ /tmp/b/1/
'/tmp/a/1/' -> '/tmp/b/1/1'
'/tmp/a/1/test.txt' -> '/tmp/b/1/1/test.txt'
```

This can be fixed by using `*` to copy from the src.

```
# Workaround
$ rm -rf /tmp/{a,b}; mkdir -p /tmp/{a,b}/1; touch /tmp/a/1/test.txt; cp -rv /tmp/a/1/* /tmp/b/1/
'/tmp/a/1/test.txt' -> '/tmp/b/1/test.txt'
```

I tested the updates on macOS (latest) and Arch and everything seems ok in my testing.