### PR TITLE
non-176ify EventTarget

### DIFF
--- a/lib/fix-rsvp.js
+++ b/lib/fix-rsvp.js
@@ -42,7 +42,6 @@ module.exports = function fixRsvp (docs) {
         'namespaces': {},
         'classes': {
           'rsvp': 1,
-          'EventTarget': 1,
           'Promise': 1
         },
         'access': 'public'
@@ -62,24 +61,17 @@ module.exports = function fixRsvp (docs) {
       doc.data.classes['Promise'].module = 'rsvp'
       doc.data.classes['Promise'].access = 'public'
 
-      doc.data.classes['EventTarget'] = doc.data.classes['RSVP.EventTarget']
-      delete doc.data.classes['RSVP.EventTarget']
-      doc.data.classes['EventTarget'].access = 'public'
-      doc.data.classes['EventTarget'].module = 'rsvp'
-      doc.data.classes['EventTarget'].name = 'EventTarget'
-      doc.data.classes['EventTarget'].shortname = 'EventTarget'
+      doc.data.classes['RSVP.EventTarget'].module = 'rsvp'
 
       doc.data.classitems = _.filter(doc.data.classitems, item => item.file.indexOf('/rsvp/promise') < 0 || item.static !== 1)
       doc.data.classitems.forEach(item => {
         if (item.class.startsWith('RSVP')) {
-          item.access = 'public'
           item.module = 'rsvp'
-          if (item.class === 'RSVP.EventTarget') {
-            item.class = 'EventTarget'
-          } else if (item.class === 'RSVP.Promise') {
+          if (item.class === 'RSVP.Promise') {
             item.class = 'Promise'
-          } else {
+          } else if (item.class !== 'RSVP.EventTarget') {
             item.class = 'rsvp'
+            item.access = 'public'
           }
         }
       })


### PR DESCRIPTION
partially addresses https://github.com/ember-learn/ember-api-docs/issues/423

RSVP namespace EventTarget was unnecessarily removed from EventTarget
Plus all methods on the class are private, so it was improperly showing up.