### PR TITLE
Decode character entities given in descriptions.

### DIFF
--- a/lib/markup.js
+++ b/lib/markup.js
@@ -36,6 +36,11 @@ function replaceDescriptionFor(items) {
 }
 
 function highlight(description) {
+	if (description) {
+		description = description.replace(/&#(\d+);/g, function(match, dec) {
+			return String.fromCharCode(dec)
+		})
+	}
 	let markedup = removeHLJSPrefix(marked(description))
 	let $ = cheerio.load(markedup)
 

--- a/package.json
+++ b/package.json
@@ -62,10 +62,5 @@
 	},
 	"cacheDirectories": [
 		"tmp"
-	],
-	"husky": {
-		"hooks": {
-			"pre-commit": "pretty-quick --staged"
-		}
-	}
+	]
 }


### PR DESCRIPTION
This is a patch for https://github.com/emberjs/ember.js/issues/18063 which lets us provide yuidoc special characters as html character code entities and decodes them before we apply highlightjs and markdown processing.

Here's a preview of the screen for the above issue
![image](https://user-images.githubusercontent.com/3609063/58726872-de62a400-83b0-11e9-87bd-f7f6265fb0f1.png)
