### PR TITLE
Revert "Bump marked from 0.7.0 to 4.0.10"

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"inflected": "^2.0.4",
 		"keyfinder": "^1.0.0",
 		"lodash": "^4.17.21",
-		"marked": "^4.0.10",
+		"marked": "^0.7.0",
 		"minimist": "^1.2.6",
 		"mkdir-promise": "^1.0.0",
 		"mkdirp": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1797,10 +1797,10 @@ map-age-cleaner@^0.1.1:
   dependencies:
     p-defer "^1.0.0"
 
-marked@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-4.0.10.tgz#423e295385cc0c3a70fa495e0df68b007b879423"
-  integrity sha512-+QvuFj0nGgO970fySghXGmuw+Fd0gD2x3+MqCWLIPf5oxdv1Ka6b2q+z9RP01P/IaKPMEramy+7cNy/Lw8c3hw==
+marked@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.7.0.tgz#b64201f051d271b1edc10a04d1ae9b74bb8e5c0e"
+  integrity sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==
 
 mem@^4.0.0:
   version "4.3.0"


### PR DESCRIPTION
This reverts commit 2333f457a7d0230e52e70125983dae13bc8f6434.

The `marked` package update caused a problem running yarn start sync.