### PR TITLE
WIP Separate script to upload to AWS

### DIFF
--- a/lib/upload-tmp-to-aws.js
+++ b/lib/upload-tmp-to-aws.js
@@ -1,0 +1,22 @@
+const RSVP = require('rsvp')
+const uploadDocsToS3 = require('./s3-sync').uploadDocsToS3
+
+// Only run this script if you have confirmed that the tmp directory's
+// contents render correctly in the ember-api-docs app, using
+// `npm run start:local` for the front end.
+// There are no safety checks here!
+async function apiDocsProcessor () {
+	console.log('Beginning S3 upload of the contents of tmp directory')
+	RSVP.on('error', reason => {
+		console.log(reason)
+		process.exit(1)
+	})
+
+	await uploadDocsToS3()
+		.then(() => {
+			console.log('\n\n\n')
+			console.log('Done!')
+		})
+}
+
+apiDocsProcessor()

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"backup": "node -r esm backup.js",
 		"gen": "node -r esm generate-local.js",
 		"greet": "echo 'hi'",
+		"upload-tmp-to-aws": "node -r esm lib/upload-tmp-to-aws.js",
 		"server": "http-server -p 5050 --cors tmp",
 		"serve": "yarn server",
 		"start": "node index.js",


### PR DESCRIPTION
Make it possible to publish docs separately from downloading and building them.

Usage:
- Make sure the docs in your tmp folder are built and work nicely in ember-api-docs using `npm run start:local`
- If you have confirmed this, set AWS_SHOULD_PUBLISH to `yes` and run `yarn upload-tmp-to-aws`