### PR TITLE
Add a script for pushing previously-built docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
 		"start": "node index.js",
 		"test:mocha": "mocha -r esm test",
 		"lint": "eslint lib/**/*.js index.js test/**.js",
-		"test": "yarn lint && yarn test:mocha"
+		"test": "yarn lint && yarn test:mocha",
+		"upload-to-aws": "node -r esm upload-tmp-to-aws.js"
 	},
 	"dependencies": {
 		"cheerio": "^1.0.0-rc.2",

--- a/upload-tmp-to-aws.js
+++ b/upload-tmp-to-aws.js
@@ -1,0 +1,35 @@
+import { uploadDocsToS3 } from './lib/s3-sync'
+import readline from 'readline'
+
+// Only run this script if you have confirmed that the tmp directory's
+// contents render correctly in the ember-api-docs app, using
+// `npm run start:local` for the front end.
+// There are no safety checks here!
+async function uploadPreviouslyBuiltDocsToS3() {
+	const prompt = readline.createInterface({
+		input: process.stdin,
+		output: process.stdout,
+	})
+
+	prompt.question(
+		'This command uploads the current contents of the tmp folder to AWS, without building the docs first. Are you sure you want to do this? yes/no \n',
+		async response => {
+			if (response === 'yes') {
+				console.log('Beginning S3 upload of the contents of tmp directory')
+
+				await uploadDocsToS3()
+					.then(() => {
+						console.log('\n\n\n')
+						console.log('Done!')
+					})
+					.catch(err => {
+						console.log(err)
+						process.exit(1)
+					})
+			}
+			prompt.close()
+		}
+	)
+}
+
+uploadPreviouslyBuiltDocsToS3()


### PR DESCRIPTION
Use this if you have already run docs generation and verified that the output works in the docs viewer, and you are ready to push to production.